### PR TITLE
bump version for proper provides installation

### DIFF
--- a/META.info
+++ b/META.info
@@ -1,6 +1,6 @@
 {
     "name" : "Encode",
-    "version" : "0.0.1",
+    "version" : "0.0.2",
     "author" : "github:sergot",
     "description" : "Character encodings in Perl 6",
     "depends" : [],


### PR DESCRIPTION
If you already have some of these modules installed, Encode::Windows1252 will fail to be built properly. Not sure if its because of the recent rakudo path changes or the provides changes. In my case the module builds and claims to have been installed correctly, but HTTP::UserAgent failed to find it until I bumped the version.
