### PR TITLE
Add unit declarator to module declarations

### DIFF
--- a/lib/Encode.pm6
+++ b/lib/Encode.pm6
@@ -1,4 +1,4 @@
-module Encode;
+unit module Encode;
 
 use Encode::Latin2;
 use Encode::Windows1252;

--- a/lib/Encode/Latin2.pm6
+++ b/lib/Encode/Latin2.pm6
@@ -1,4 +1,4 @@
-module Encode::Latin2;
+unit module Encode::Latin2;
 
 our %map =
     0xA0 => 0x0a0,

--- a/lib/Encode/Windows1252.pm6
+++ b/lib/Encode/Windows1252.pm6
@@ -1,4 +1,4 @@
-module Encode::Windows1252;
+unit module Encode::Windows1252;
 
 our %map =
     0x80 => 0x20ac,


### PR DESCRIPTION
As of Rakudo 2015.05, the `unit` declarator is required before using
`module`, `class` or `grammar` declarations (unless it uses a block).  Code
still using the old blockless semicolon form will throw a warning. This
commit stops the warning from appearing in the new Rakudo.
